### PR TITLE
Add default implementations for Solver and Variable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,12 @@ impl Variable {
     }
 }
 
+impl Default for Variable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A variable and a coefficient to multiply that variable by. This is a sub-expression in
 /// a constraint equation.
 #[derive(Copy, Clone, Debug)]

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -768,3 +768,9 @@ impl Solver {
         true
     }
 }
+
+impl Default for Solver {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
Hi! I'm looking to use this library for a UI toolkit for `amethyst` and noticed there weren't `Default` implementations for some structs that could use it, which would make it easier to implement `Default` on structs that own them. Looking forward to using the library :+1: