### PR TITLE
Various fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,3 @@ license = "MIT / Apache-2.0"
 keywords = ["constraint", "simplex", "user", "interface", "layout"]
 
 [dependencies]
-log = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ license = "MIT / Apache-2.0"
 keywords = ["constraint", "simplex", "user", "interface", "layout"]
 
 [dependencies]
+log = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,17 @@ pub enum RelationalOperator {
     GreaterOrEqual
 }
 
+impl std::fmt::Display for RelationalOperator {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            RelationalOperator::LessOrEqual => write!(fmt, "<=") ?,
+            RelationalOperator::Equal => write!(fmt, "==") ?,
+            RelationalOperator::GreaterOrEqual => write!(fmt, ">=") ?,
+        };
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 struct ConstraintData {
     expression: Expression,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,9 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use std::collections::hash_map::{Entry};
 
+#[macro_use]
+extern crate log;
+
 mod solver_impl;
 mod operators;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,9 +229,6 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use std::collections::hash_map::{Entry};
 
-#[macro_use]
-extern crate log;
-
 mod solver_impl;
 mod operators;
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -16,6 +16,12 @@ impl ops::BitOr<WeightedRelation> for f64 {
         PartialConstraint(self.into(), r)
     }
 }
+impl ops::BitOr<WeightedRelation> for f32 {
+    type Output = PartialConstraint;
+    fn bitor(self, r: WeightedRelation) -> PartialConstraint {
+        (self as f64).bitor(r)
+    }
+}
 impl ops::BitOr<WeightedRelation> for Variable {
     type Output = PartialConstraint;
     fn bitor(self, r: WeightedRelation) -> PartialConstraint {
@@ -40,6 +46,12 @@ impl ops::BitOr<f64> for PartialConstraint {
     fn bitor(self, rhs: f64) -> Constraint {
         let (op, s) = self.1.into();
         Constraint::new(self.0 - rhs, op, s)
+    }
+}
+impl ops::BitOr<f32> for PartialConstraint {
+    type Output = Constraint;
+    fn bitor(self, rhs: f32) -> Constraint {
+        self.bitor(rhs as f64)
     }
 }
 impl ops::BitOr<Variable> for PartialConstraint {
@@ -73,10 +85,24 @@ impl ops::Add<f64> for Variable {
     }
 }
 
+impl ops::Add<f32> for Variable {
+    type Output = Expression;
+    fn add(self, v: f32) -> Expression {
+        self.add(v as f64)
+    }
+}
+
 impl ops::Add<Variable> for f64 {
     type Output = Expression;
     fn add(self, v: Variable) -> Expression {
         Expression::new(vec![Term::new(v, 1.0)], self)
+    }
+}
+
+impl ops::Add<Variable> for f32 {
+    type Output = Expression;
+    fn add(self, v: Variable) -> Expression {
+        (self as f64).add(v)
     }
 }
 
@@ -131,10 +157,24 @@ impl ops::Sub<f64> for Variable {
     }
 }
 
+impl ops::Sub<f32> for Variable {
+    type Output = Expression;
+    fn sub(self, v: f32) -> Expression {
+        self.sub(v as f64)
+    }
+}
+
 impl ops::Sub<Variable> for f64 {
     type Output = Expression;
     fn sub(self, v: Variable) -> Expression {
         Expression::new(vec![Term::new(v, -1.0)], self)
+    }
+}
+
+impl ops::Sub<Variable> for f32 {
+    type Output = Expression;
+    fn sub(self, v: Variable) -> Expression {
+        (self as f64).sub(v)
     }
 }
 
@@ -183,6 +223,13 @@ impl ops::Mul<f64> for Variable {
     }
 }
 
+impl ops::Mul<f32> for Variable {
+    type Output = Term;
+    fn mul(self, v: f32) -> Term {
+        self.mul(v as f64)
+    }
+}
+
 impl ops::Mul<Variable> for f64 {
     type Output = Term;
     fn mul(self, v: Variable) -> Term {
@@ -190,10 +237,24 @@ impl ops::Mul<Variable> for f64 {
     }
 }
 
+impl ops::Mul<Variable> for f32 {
+    type Output = Term;
+    fn mul(self, v: Variable) -> Term {
+        (self as f64).mul(v)
+    }
+}
+
 impl ops::Div<f64> for Variable {
     type Output = Term;
     fn div(self, v: f64) -> Term {
         Term::new(self, 1.0 / v)
+    }
+}
+
+impl ops::Div<f32> for Variable {
+    type Output = Term;
+    fn div(self, v: f32) -> Term {
+        self.div(v as f64)
     }
 }
 
@@ -207,11 +268,25 @@ impl ops::Mul<f64> for Term {
     }
 }
 
+impl ops::Mul<f32> for Term {
+    type Output = Term;
+    fn mul(self, v: f32) -> Term {
+        self.mul(v as f64)
+    }
+}
+
 impl ops::Mul<Term> for f64 {
     type Output = Term;
     fn mul(self, mut t: Term) -> Term {
         t.coefficient *= self;
         t
+    }
+}
+
+impl ops::Mul<Term> for f32 {
+    type Output = Term;
+    fn mul(self, t: Term) -> Term {
+        (self as f64).mul(t)
     }
 }
 
@@ -223,6 +298,13 @@ impl ops::Div<f64> for Term {
     }
 }
 
+impl ops::Div<f32> for Term {
+    type Output = Term;
+    fn div(self, v: f32) -> Term {
+        self.div(v as f64)
+    }
+}
+
 impl ops::Add<f64> for Term {
     type Output = Expression;
     fn add(self, v: f64) -> Expression {
@@ -230,10 +312,24 @@ impl ops::Add<f64> for Term {
     }
 }
 
+impl ops::Add<f32> for Term {
+    type Output = Expression;
+    fn add(self, v: f32) -> Expression {
+        self.add(v as f64)
+    }
+}
+
 impl ops::Add<Term> for f64 {
     type Output = Expression;
     fn add(self, t: Term) -> Expression {
         Expression::new(vec![t], self)
+    }
+}
+
+impl ops::Add<Term> for f32 {
+    type Output = Expression;
+    fn add(self, t: Term) -> Expression {
+        (self as f64).add(t)
     }
 }
 
@@ -275,10 +371,24 @@ impl ops::Sub<f64> for Term {
     }
 }
 
+impl ops::Sub<f32> for Term {
+    type Output = Expression;
+    fn sub(self, v: f32) -> Expression {
+        self.sub(v as f64)
+    }
+}
+
 impl ops::Sub<Term> for f64 {
     type Output = Expression;
     fn sub(self, t: Term) -> Expression {
         Expression::new(vec![-t], self)
+    }
+}
+
+impl ops::Sub<Term> for f32 {
+    type Output = Expression;
+    fn sub(self, t: Term) -> Expression {
+        (self as f64).sub(t)
     }
 }
 
@@ -319,6 +429,13 @@ impl ops::Mul<f64> for Expression {
     }
 }
 
+impl ops::Mul<f32> for Expression {
+    type Output = Expression;
+    fn mul(self, v: f32) -> Expression {
+        self.mul(v as f64)
+    }
+}
+
 impl ops::Mul<Expression> for f64 {
     type Output = Expression;
     fn mul(self, mut e: Expression) -> Expression {
@@ -327,6 +444,13 @@ impl ops::Mul<Expression> for f64 {
             *t = *t * self;
         }
         e
+    }
+}
+
+impl ops::Mul<Expression> for f32 {
+    type Output = Expression;
+    fn mul(self, e: Expression) -> Expression {
+        (self as f64).mul(e)
     }
 }
 
@@ -341,6 +465,13 @@ impl ops::Div<f64> for Expression {
     }
 }
 
+impl ops::Div<f32> for Expression {
+    type Output = Expression;
+    fn div(self, v: f32) -> Expression {
+        self.div(v as f64)
+    }
+}
+
 impl ops::Add<f64> for Expression {
     type Output = Expression;
     fn add(mut self, v: f64) -> Expression {
@@ -349,11 +480,25 @@ impl ops::Add<f64> for Expression {
     }
 }
 
+impl ops::Add<f32> for Expression {
+    type Output = Expression;
+    fn add(self, v: f32) -> Expression {
+        self.add(v as f64)
+    }
+}
+
 impl ops::Add<Expression> for f64 {
     type Output = Expression;
     fn add(self, mut e: Expression) -> Expression {
         e.constant += self;
         e
+    }
+}
+
+impl ops::Add<Expression> for f32 {
+    type Output = Expression;
+    fn add(self, e: Expression) -> Expression {
+        (self as f64).add(e)
     }
 }
 
@@ -382,12 +527,26 @@ impl ops::Sub<f64> for Expression {
     }
 }
 
+impl ops::Sub<f32> for Expression {
+    type Output = Expression;
+    fn sub(self, v: f32) -> Expression {
+        self.sub(v as f64)
+    }
+}
+
 impl ops::Sub<Expression> for f64 {
     type Output = Expression;
     fn sub(self, mut e: Expression) -> Expression {
         e.negate();
         e.constant += self;
         e
+    }
+}
+
+impl ops::Sub<Expression> for f32 {
+    type Output = Expression;
+    fn sub(self, e: Expression) -> Expression {
+        (self as f64).sub(e)
     }
 }
 

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -317,7 +317,7 @@ impl Solver {
                     self.public_changes.push((v, new_value));
                     var_data.0 = new_value;
                 } else {
-                    println!("Spurious change");
+                    info!("Spurious change");
                 }
             }
         }

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -583,9 +583,8 @@ impl Solver {
     fn dual_optimise(&mut self) -> Result<(), InternalSolverError> {
         while !self.infeasible_rows.is_empty() {
             let leaving = self.infeasible_rows.pop().unwrap();
-            if let Some(mut row) = self.rows.remove(&leaving)
-                .and_then(|row| if row.constant < 0.0 { Some(row) } else { None })
-            {
+            if self.rows.get(&leaving).map_or(false, |row| row.constant < 0.0) {
+                let mut row = self.rows.remove(&leaving).unwrap();
                 let entering = self.get_dual_entering_symbol(&row);
                 if entering.type_() == SymbolType::Invalid {
                     return Err(InternalSolverError("Dual optimise failed."));

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -314,8 +314,6 @@ impl Solver {
                 if old_value != new_value {
                     self.public_changes.push((v, new_value));
                     var_data.0 = new_value;
-                } else {
-                    info!("Spurious change");
                 }
             }
         }

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -767,4 +767,14 @@ impl Solver {
         }
         true
     }
+
+    /// Get the stored value for a variable.
+    ///
+    /// Normally values should be retrieved and updated using `fetch_changes`, but
+    /// this method can be used for debugging or testing.
+    pub fn get_value(&self, v: Variable) -> f64 {
+        self.var_data.get(&v).and_then(|s| {
+            self.rows.get(&s.1).map(|r| r.constant)
+        }).unwrap_or(0.0)
+    }
 }

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -299,9 +299,6 @@ impl Solver {
     ///
     /// The list of changes returned is not in a specific order. Each change comprises the variable changed and
     /// the new value of that variable.
-    ///
-    /// Note that variables start with an implicit value of zero.
-    /// If a variable never changes from zero a change may not be returned from this function for it.
     pub fn fetch_changes(&mut self) -> &[(Variable, f64)] {
         if self.should_clear_changes {
             self.changed.clear();

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -225,7 +225,7 @@ impl Solver {
     }
 
     /// Test whether an edit variable has been added to the solver.
-    pub fn has_edit_variable(&mut self, v: &Variable) -> bool {
+    pub fn has_edit_variable(&self, v: &Variable) -> bool {
         self.edits.contains_key(v)
     }
 

--- a/src/solver_impl.rs
+++ b/src/solver_impl.rs
@@ -355,7 +355,7 @@ impl Solver {
             let s = Symbol(*id_tick, SymbolType::External);
             var_for_symbol.insert(s, v);
             *id_tick += 1;
-            (0.0, s, 0)
+            (::std::f64::NAN, s, 0)
         });
         value.2 += 1;
         value.1

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use cassowary::Variable;
+
+#[derive(Clone, Default)]
+struct Values(Rc<RefCell<HashMap<Variable, f64>>>);
+
+impl Values {
+    fn value_of(&self, var: Variable) -> f64 {
+        *self.0.borrow().get(&var).unwrap_or(&0.0)
+    }
+    fn update_values(&self, changes: &[(Variable, f64)]) {
+        for &(ref var, ref value) in changes {
+            println!("{:?} changed to {:?}", var, value);
+            self.0.borrow_mut().insert(*var, *value);
+        }
+    }
+}
+
+pub fn new_values() -> (Box<Fn(Variable) -> f64>, Box<Fn(&[(Variable, f64)])>) {
+    let values = Values(Rc::new(RefCell::new(HashMap::new())));
+    let value_of = {
+        let values = values.clone();
+        move |v| values.value_of(v)
+    };
+    let update_values = {
+        let values = values.clone();
+        move |changes: &[_]| {
+            values.update_values(changes);
+        }
+    };
+    (Box::new(value_of), Box::new(update_values))
+}

--- a/tests/quadrilateral.rs
+++ b/tests/quadrilateral.rs
@@ -1,9 +1,10 @@
 extern crate cassowary;
 use cassowary::{ Solver, Variable };
 use cassowary::WeightedRelation::*;
-use std::collections::HashMap;
-use std::cell::RefCell;
-use std::rc::Rc;
+
+mod common;
+use common::new_values;
+
 #[test]
 fn test_quadrilateral() {
     use cassowary::strength::{WEAK, STRONG, REQUIRED};
@@ -19,21 +20,7 @@ fn test_quadrilateral() {
             }
         }
     }
-
-    let values = Rc::new(RefCell::new(HashMap::<Variable, f64>::new()));
-    let value_of = {
-        let values = values.clone();
-        move |v| *values.borrow().get(&v).unwrap_or(&0.0)
-    };
-    let update_values = {
-        let values = values.clone();
-        move |changes: &[_]| {
-            for &(ref var, ref value) in changes {
-                println!("{:?} changed to {:?}", var, value);
-                values.borrow_mut().insert(*var, *value);
-            }
-        }
-    };
+    let (value_of, update_values) = new_values();
 
     let points = [Point::new(),
                   Point::new(),

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,0 +1,30 @@
+extern crate cassowary;
+
+use cassowary::{Variable, Solver, Constraint};
+use cassowary::WeightedRelation::*;
+use cassowary::strength::*;
+
+mod common;
+
+use common::new_values;
+
+#[test]
+fn remove_constraint() {
+    let (value_of, update_values) = new_values();
+
+    let mut solver = Solver::new();
+
+    let val = Variable::new();
+
+    let constraint: Constraint = val | EQ(REQUIRED) | 100.0;
+    solver.add_constraint(constraint.clone()).unwrap();
+    update_values(solver.fetch_changes());
+
+    assert_eq!(value_of(val), 100.0);
+
+    solver.remove_constraint(&constraint).unwrap();
+    solver.add_constraint(val | EQ(REQUIRED) | 0.0).unwrap();
+    update_values(solver.fetch_changes());
+
+    assert_eq!(value_of(val), 0.0);
+}


### PR DESCRIPTION
This contains various changes made as part of my work on a higher level wrapper library around cassowary-rs, it includes two significant bug fixes and other smaller changes. If it helps, I can split this up into multiple pull requests.

The most serious bug is fixed by the last commit, which fixes an `InternalSolverError` that can occur with sufficiently complex layouts. I could only reproduce it with a complicated layout example, otherwise I would have added a minimal test case. Hopefully the fix is clear by comparing the change to kiwi's dual optimize: https://github.com/nucleic/kiwi/blob/master/kiwi/solverimpl.h#L600

The other bug (fixed by second last commit) includes a short test case that should demonstrate the issue.

I added a dependency on the log crate so that 'Spurious change' can be just an info! message and isn't always dumped to console, I figured it's alright since it's a tiny dependency and it could be useful to add more debug! or error! log messages in the future. Alternatively, the 'Spurious change' message could probably just be removed.